### PR TITLE
Refactor to Enable Custom REST Headers (for Application Options)

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -7,6 +7,7 @@ require (
 	github.com/google/uuid v1.3.0
 	github.com/gordonklaus/portaudio v0.0.0-20220320131553-cc649ad523c1
 	github.com/gorilla/websocket v1.5.0
+	github.com/hokaccha/go-prettyjson v0.0.0-20211117102719-0474bc63780f
 	gopkg.in/go-playground/validator.v9 v9.31.0
 	k8s.io/klog/v2 v2.80.1
 )
@@ -16,7 +17,6 @@ require (
 	github.com/go-logr/logr v1.2.0 // indirect
 	github.com/go-playground/locales v0.14.0 // indirect
 	github.com/go-playground/universal-translator v0.18.0 // indirect
-	github.com/hokaccha/go-prettyjson v0.0.0-20211117102719-0474bc63780f // indirect
 	github.com/leodido/go-urn v1.2.1 // indirect
 	github.com/mattn/go-colorable v0.1.9 // indirect
 	github.com/mattn/go-isatty v0.0.14 // indirect
@@ -24,6 +24,6 @@ require (
 	gopkg.in/go-playground/assert.v1 v1.2.1 // indirect
 )
 
-replace github.com/gorilla/websocket => github.com/dvonthenen/websocket v1.5.1-0.20221123154619-09865dbf1be2
+replace github.com/gorilla/websocket => github.com/dvonthenen/websocket v1.5.1-0.20230208185225-642cd054e185
 
 // replace github.com/gorilla/websocket => ../../gorilla/websocket

--- a/go.sum
+++ b/go.sum
@@ -1,7 +1,7 @@
 github.com/davecgh/go-spew v1.1.0 h1:ZDRjVQ15GmhC3fiQ8ni8+OwkZQO4DARzQgrnXU1Liz8=
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
-github.com/dvonthenen/websocket v1.5.1-0.20221123154619-09865dbf1be2 h1:rsU8o6R7JTsP1c8WnXQhbaGRITJgL+SeDgc6zsFTfSU=
-github.com/dvonthenen/websocket v1.5.1-0.20221123154619-09865dbf1be2/go.mod h1:YR8l580nyteQvAITg2hZ9XVh4b55+EU/adAjf1fMHhE=
+github.com/dvonthenen/websocket v1.5.1-0.20230208185225-642cd054e185 h1:njUDVTY8VzBruYQTpVoI4mW3ucZ91erCrB1CnPHuQQc=
+github.com/dvonthenen/websocket v1.5.1-0.20230208185225-642cd054e185/go.mod h1:YR8l580nyteQvAITg2hZ9XVh4b55+EU/adAjf1fMHhE=
 github.com/fatih/color v1.13.0 h1:8LOYc1KYPPmyKMuN8QV2DNRWNbLo6LZ0iLs8+mlH53w=
 github.com/fatih/color v1.13.0/go.mod h1:kLAiJbzzSOZDVNGyDpeOxJ47H46qBXwg5ILebYFFOfk=
 github.com/go-logr/logr v1.2.0 h1:QK40JKJyMdUDz+h+xvCsru/bJhvG0UxvePV0ufL/AcE=

--- a/pkg/api/async/v1/async.go
+++ b/pkg/api/async/v1/async.go
@@ -11,9 +11,10 @@ import (
 	validator "gopkg.in/go-playground/validator.v9"
 	klog "k8s.io/klog/v2"
 
-	interfaces "github.com/dvonthenen/symbl-go-sdk/pkg/api/async/v1/interfaces"
+	asyncinterfaces "github.com/dvonthenen/symbl-go-sdk/pkg/api/async/v1/interfaces"
 	version "github.com/dvonthenen/symbl-go-sdk/pkg/api/version"
-	symbl "github.com/dvonthenen/symbl-go-sdk/pkg/client"
+	client "github.com/dvonthenen/symbl-go-sdk/pkg/client"
+	interfaces "github.com/dvonthenen/symbl-go-sdk/pkg/client/interfaces"
 )
 
 const (
@@ -22,19 +23,19 @@ const (
 )
 
 type Client struct {
-	*symbl.RestClient
+	*client.RestClient
 }
 
-func New(client *symbl.RestClient) *Client {
+func New(client *client.RestClient) *Client {
 	return &Client{client}
 }
 
 func (c *Client) PostText(ctx context.Context, messages []string) (*JobConversation, error) {
-	textRequest := interfaces.AsyncTextRequest{}
+	textRequest := asyncinterfaces.AsyncTextRequest{}
 
 	for _, message := range messages {
-		textRequest.Messages = append(textRequest.Messages, interfaces.TextMessage{
-			Payload: interfaces.Payload{
+		textRequest.Messages = append(textRequest.Messages, asyncinterfaces.TextMessage{
+			Payload: asyncinterfaces.Payload{
 				Content: message,
 			},
 			From:     nil,
@@ -46,11 +47,11 @@ func (c *Client) PostText(ctx context.Context, messages []string) (*JobConversat
 }
 
 func (c *Client) PostAppendText(ctx context.Context, conversationId string, messages []string) (*JobConversation, error) {
-	textRequest := interfaces.AsyncTextRequest{}
+	textRequest := asyncinterfaces.AsyncTextRequest{}
 
 	for _, message := range messages {
-		textRequest.Messages = append(textRequest.Messages, interfaces.TextMessage{
-			Payload: interfaces.Payload{
+		textRequest.Messages = append(textRequest.Messages, asyncinterfaces.TextMessage{
+			Payload: asyncinterfaces.Payload{
 				Content: message,
 			},
 			From:     nil,
@@ -62,18 +63,18 @@ func (c *Client) PostAppendText(ctx context.Context, conversationId string, mess
 }
 
 func (c *Client) PostFile(ctx context.Context, filePath string) (*JobConversation, error) {
-	options := interfaces.AsyncOptions{}
+	options := asyncinterfaces.AsyncOptions{}
 	return c.PostFileWithOptions(ctx, filePath, options)
 }
 
 func (c *Client) PostURL(ctx context.Context, url string) (*JobConversation, error) {
-	options := interfaces.AsyncOptions{
+	options := asyncinterfaces.AsyncOptions{
 		URL: url,
 	}
 	return c.PostURLWithOptions(ctx, options)
 }
 
-func (c *Client) PostURLWithOptions(ctx context.Context, options interfaces.AsyncOptions) (*JobConversation, error) {
+func (c *Client) PostURLWithOptions(ctx context.Context, options asyncinterfaces.AsyncOptions) (*JobConversation, error) {
 	klog.V(6).Infof("async.PostURLWithOptions ENTER\n")
 
 	// checks
@@ -87,7 +88,7 @@ func (c *Client) PostURLWithOptions(ctx context.Context, options interfaces.Asyn
 	var jobConvo JobConversation
 
 	err := c.DoURLWithOptions(ctx, options, &jobConvo)
-	if e, ok := err.(*symbl.StatusError); ok {
+	if e, ok := err.(*interfaces.StatusError); ok {
 		klog.V(1).Infof("DoURL failed. HTTP Code: %v\n", e.Resp.StatusCode)
 		klog.V(6).Infof("async.PostURLWithOptions LEAVE\n")
 		return nil, e
@@ -98,7 +99,7 @@ func (c *Client) PostURLWithOptions(ctx context.Context, options interfaces.Asyn
 	return &jobConvo, nil
 }
 
-func (c *Client) PostFileWithOptions(ctx context.Context, filePath string, options interfaces.AsyncOptions) (*JobConversation, error) {
+func (c *Client) PostFileWithOptions(ctx context.Context, filePath string, options asyncinterfaces.AsyncOptions) (*JobConversation, error) {
 	klog.V(6).Infof("async.PostFileWithOptions ENTER\n")
 
 	// checks
@@ -112,7 +113,7 @@ func (c *Client) PostFileWithOptions(ctx context.Context, filePath string, optio
 	var jobConvo JobConversation
 
 	err := c.DoFileWithOptions(ctx, filePath, options, &jobConvo)
-	if e, ok := err.(*symbl.StatusError); ok {
+	if e, ok := err.(*interfaces.StatusError); ok {
 		klog.V(1).Infof("DoFile failed. HTTP Code: %v\n", e.Resp.StatusCode)
 		klog.V(6).Infof("async.PostFileWithOptions LEAVE\n")
 		return nil, e
@@ -150,7 +151,7 @@ func (c *Client) WaitForJobCompleteOnce(ctx context.Context, jobId string) (bool
 
 	err = c.Client.Do(ctx, req, &jobStatus)
 
-	if e, ok := err.(*symbl.StatusError); ok {
+	if e, ok := err.(*interfaces.StatusError); ok {
 		if e.Resp.StatusCode != http.StatusOK {
 			klog.V(1).Infof("HTTP Code: %v\n", e.Resp.StatusCode)
 			klog.V(6).Infof("async.WaitForJobCompleteOnce LEAVE\n")
@@ -165,7 +166,7 @@ func (c *Client) WaitForJobCompleteOnce(ctx context.Context, jobId string) (bool
 	return complete, nil
 }
 
-func (c *Client) PostTextWithOptions(ctx context.Context, textRequest interfaces.AsyncTextRequest) (*JobConversation, error) {
+func (c *Client) PostTextWithOptions(ctx context.Context, textRequest asyncinterfaces.AsyncTextRequest) (*JobConversation, error) {
 	klog.V(6).Infof("async.PostTextWithOptions ENTER\n")
 
 	// checks
@@ -177,7 +178,7 @@ func (c *Client) PostTextWithOptions(ctx context.Context, textRequest interfaces
 	var jobConvo JobConversation
 
 	err := c.DoTextWithOptions(ctx, textRequest, &jobConvo)
-	if e, ok := err.(*symbl.StatusError); ok {
+	if e, ok := err.(*interfaces.StatusError); ok {
 		klog.V(1).Infof("DoURL failed. HTTP Code: %v\n", e.Resp.StatusCode)
 		klog.V(6).Infof("async.PostTextWithOptions LEAVE\n")
 		return nil, e
@@ -188,7 +189,7 @@ func (c *Client) PostTextWithOptions(ctx context.Context, textRequest interfaces
 	return &jobConvo, nil
 }
 
-func (c *Client) PostAppendTextWithOptions(ctx context.Context, conversationId string, textRequest interfaces.AsyncTextRequest) (*JobConversation, error) {
+func (c *Client) PostAppendTextWithOptions(ctx context.Context, conversationId string, textRequest asyncinterfaces.AsyncTextRequest) (*JobConversation, error) {
 	klog.V(6).Infof("async.PostAppendTextWithOptions ENTER\n")
 
 	// checks
@@ -200,7 +201,7 @@ func (c *Client) PostAppendTextWithOptions(ctx context.Context, conversationId s
 	var jobConvo JobConversation
 
 	err := c.DoAppendTextWithOptions(ctx, conversationId, textRequest, &jobConvo)
-	if e, ok := err.(*symbl.StatusError); ok {
+	if e, ok := err.(*interfaces.StatusError); ok {
 		klog.V(1).Infof("DoURL failed. HTTP Code: %v\n", e.Resp.StatusCode)
 		klog.V(6).Infof("async.PostAppendTextWithOptions LEAVE\n")
 		return nil, e
@@ -211,7 +212,7 @@ func (c *Client) PostAppendTextWithOptions(ctx context.Context, conversationId s
 	return &jobConvo, nil
 }
 
-func (c *Client) WaitForJobComplete(ctx context.Context, jobStatusOpts interfaces.WaitForJobStatusOpts) (bool, error) {
+func (c *Client) WaitForJobComplete(ctx context.Context, jobStatusOpts asyncinterfaces.WaitForJobStatusOpts) (bool, error) {
 	klog.V(6).Infof("async.WaitForJobComplete ENTER\n")
 
 	// validate input
@@ -237,7 +238,7 @@ func (c *Client) WaitForJobComplete(ctx context.Context, jobStatusOpts interface
 	}
 
 	numOfLoops := float64(defaultWaitForCompletion) / float64(defaultDelayBetweenCheck)
-	if jobStatusOpts.WaitInSeconds != interfaces.UseDefaultWaitForCompletion {
+	if jobStatusOpts.WaitInSeconds != asyncinterfaces.UseDefaultWaitForCompletion {
 		numOfLoops = float64(jobStatusOpts.WaitInSeconds) / float64(defaultDelayBetweenCheck)
 		klog.V(4).Infof("User provided jobStatusOpts.WaitInSeconds\n")
 	}

--- a/pkg/api/async/v1/bookmarks.go
+++ b/pkg/api/async/v1/bookmarks.go
@@ -13,13 +13,12 @@ import (
 	validator "gopkg.in/go-playground/validator.v9"
 	klog "k8s.io/klog/v2"
 
+	asyncinterfaces "github.com/dvonthenen/symbl-go-sdk/pkg/api/async/v1/interfaces"
 	version "github.com/dvonthenen/symbl-go-sdk/pkg/api/version"
-	symbl "github.com/dvonthenen/symbl-go-sdk/pkg/client"
-
-	interfaces "github.com/dvonthenen/symbl-go-sdk/pkg/api/async/v1/interfaces"
+	interfaces "github.com/dvonthenen/symbl-go-sdk/pkg/client/interfaces"
 )
 
-func (c *Client) GetBookmarks(ctx context.Context, conversationId string) (*interfaces.BookmarksResult, error) {
+func (c *Client) GetBookmarks(ctx context.Context, conversationId string) (*asyncinterfaces.BookmarksResult, error) {
 	klog.V(6).Infof("async.GetBookmarks ENTER\n")
 
 	// checks
@@ -44,11 +43,11 @@ func (c *Client) GetBookmarks(ctx context.Context, conversationId string) (*inte
 	}
 
 	// check the status
-	var result interfaces.BookmarksResult
+	var result asyncinterfaces.BookmarksResult
 
 	err = c.Client.Do(ctx, req, &result)
 
-	if e, ok := err.(*symbl.StatusError); ok {
+	if e, ok := err.(*interfaces.StatusError); ok {
 		if e.Resp.StatusCode != http.StatusOK {
 			klog.V(1).Infof("HTTP Code: %v\n", e.Resp.StatusCode)
 			klog.V(6).Infof("async.GetBookmarks LEAVE\n")
@@ -61,7 +60,7 @@ func (c *Client) GetBookmarks(ctx context.Context, conversationId string) (*inte
 	return &result, nil
 }
 
-func (c *Client) GetBookmarkById(ctx context.Context, conversationId, bookmarkId string) (*interfaces.BookmarksResult, error) {
+func (c *Client) GetBookmarkById(ctx context.Context, conversationId, bookmarkId string) (*asyncinterfaces.BookmarksResult, error) {
 	klog.V(6).Infof("async.GetBookmarkById ENTER\n")
 
 	// checks
@@ -91,11 +90,11 @@ func (c *Client) GetBookmarkById(ctx context.Context, conversationId, bookmarkId
 	}
 
 	// check the status
-	var result interfaces.BookmarksResult
+	var result asyncinterfaces.BookmarksResult
 
 	err = c.Client.Do(ctx, req, &result)
 
-	if e, ok := err.(*symbl.StatusError); ok {
+	if e, ok := err.(*interfaces.StatusError); ok {
 		if e.Resp.StatusCode != http.StatusOK {
 			klog.V(1).Infof("HTTP Code: %v\n", e.Resp.StatusCode)
 			klog.V(6).Infof("async.GetBookmarkById LEAVE\n")
@@ -116,7 +115,7 @@ func (c *Client) GetBookmarkById(ctx context.Context, conversationId, bookmarkId
 		"message":"\"description\" is not allowed to be empty"
 	}
 */
-func (c *Client) CreateBookmark(ctx context.Context, conversationId string, request interfaces.BookmarkRequest) (*interfaces.Bookmark, error) {
+func (c *Client) CreateBookmark(ctx context.Context, conversationId string, request asyncinterfaces.BookmarkRequest) (*asyncinterfaces.Bookmark, error) {
 	klog.V(6).Infof("async.CreateBookmark ENTER\n")
 
 	// checks
@@ -159,11 +158,11 @@ func (c *Client) CreateBookmark(ctx context.Context, conversationId string, requ
 	}
 
 	// check the status
-	var result interfaces.Bookmark
+	var result asyncinterfaces.Bookmark
 
 	err = c.Client.Do(ctx, req, &result)
 
-	if e, ok := err.(*symbl.StatusError); ok {
+	if e, ok := err.(*interfaces.StatusError); ok {
 		if e.Resp.StatusCode != http.StatusOK {
 			klog.V(1).Infof("HTTP Code: %v\n", e.Resp.StatusCode)
 			klog.V(6).Infof("async.CreateBookmark LEAVE\n")
@@ -176,7 +175,7 @@ func (c *Client) CreateBookmark(ctx context.Context, conversationId string, requ
 	return &result, nil
 }
 
-func (c *Client) UpdateBookmark(ctx context.Context, conversationId, bookmarkId string, request interfaces.BookmarkRequest) (*interfaces.Bookmark, error) {
+func (c *Client) UpdateBookmark(ctx context.Context, conversationId, bookmarkId string, request asyncinterfaces.BookmarkRequest) (*asyncinterfaces.Bookmark, error) {
 	klog.V(6).Infof("async.UpdateBookmark ENTER\n")
 
 	// checks
@@ -224,11 +223,11 @@ func (c *Client) UpdateBookmark(ctx context.Context, conversationId, bookmarkId 
 	}
 
 	// check the status
-	var result interfaces.Bookmark
+	var result asyncinterfaces.Bookmark
 
 	err = c.Client.Do(ctx, req, &result)
 
-	if e, ok := err.(*symbl.StatusError); ok {
+	if e, ok := err.(*interfaces.StatusError); ok {
 		if e.Resp.StatusCode != http.StatusOK {
 			klog.V(1).Infof("HTTP Code: %v\n", e.Resp.StatusCode)
 			klog.V(6).Infof("async.UpdateBookmark LEAVE\n")
@@ -275,7 +274,7 @@ func (c *Client) DeleteBookmark(ctx context.Context, conversationId, bookmarkId 
 	// check the status
 	err = c.Client.Do(ctx, req, nil)
 
-	if e, ok := err.(*symbl.StatusError); ok {
+	if e, ok := err.(*interfaces.StatusError); ok {
 		if e.Resp.StatusCode != http.StatusOK {
 			klog.V(1).Infof("HTTP Code: %v\n", e.Resp.StatusCode)
 			klog.V(6).Infof("async.DeleteBookmark LEAVE\n")
@@ -288,7 +287,7 @@ func (c *Client) DeleteBookmark(ctx context.Context, conversationId, bookmarkId 
 	return nil
 }
 
-func (c *Client) GetSummaryOfBookmark(ctx context.Context, conversationId, bookmarkId string) (*interfaces.BookmarkSummaryResult, error) {
+func (c *Client) GetSummaryOfBookmark(ctx context.Context, conversationId, bookmarkId string) (*asyncinterfaces.BookmarkSummaryResult, error) {
 	klog.V(6).Infof("async.GetSummaryOfBookmark ENTER\n")
 
 	// checks
@@ -318,11 +317,11 @@ func (c *Client) GetSummaryOfBookmark(ctx context.Context, conversationId, bookm
 	}
 
 	// check the status
-	var result interfaces.BookmarkSummaryResult
+	var result asyncinterfaces.BookmarkSummaryResult
 
 	err = c.Client.Do(ctx, req, &result)
 
-	if e, ok := err.(*symbl.StatusError); ok {
+	if e, ok := err.(*interfaces.StatusError); ok {
 		if e.Resp.StatusCode != http.StatusOK {
 			klog.V(1).Infof("HTTP Code: %v\n", e.Resp.StatusCode)
 			klog.V(6).Infof("async.GetSummaryOfBookmark LEAVE\n")
@@ -335,7 +334,7 @@ func (c *Client) GetSummaryOfBookmark(ctx context.Context, conversationId, bookm
 	return &result, nil
 }
 
-func (c *Client) GetSummaryOfBookmarks(ctx context.Context, conversationId string, filters []string) (*interfaces.BookmarksSummaryResult, error) {
+func (c *Client) GetSummaryOfBookmarks(ctx context.Context, conversationId string, filters []string) (*asyncinterfaces.BookmarksSummaryResult, error) {
 	klog.V(6).Infof("async.GetSummaryOfBookmarks ENTER\n")
 
 	// checks
@@ -371,11 +370,11 @@ func (c *Client) GetSummaryOfBookmarks(ctx context.Context, conversationId strin
 	}
 
 	// check the status
-	var result interfaces.BookmarksSummaryResult
+	var result asyncinterfaces.BookmarksSummaryResult
 
 	err = c.Client.Do(ctx, req, &result)
 
-	if e, ok := err.(*symbl.StatusError); ok {
+	if e, ok := err.(*interfaces.StatusError); ok {
 		if e.Resp.StatusCode != http.StatusOK {
 			klog.V(1).Infof("HTTP Code: %v\n", e.Resp.StatusCode)
 			klog.V(6).Infof("async.GetSummaryOfBookmarks LEAVE\n")

--- a/pkg/api/async/v1/conversation.go
+++ b/pkg/api/async/v1/conversation.go
@@ -9,13 +9,12 @@ import (
 
 	klog "k8s.io/klog/v2"
 
+	asyncinterfaces "github.com/dvonthenen/symbl-go-sdk/pkg/api/async/v1/interfaces"
 	version "github.com/dvonthenen/symbl-go-sdk/pkg/api/version"
-	symbl "github.com/dvonthenen/symbl-go-sdk/pkg/client"
-
-	interfaces "github.com/dvonthenen/symbl-go-sdk/pkg/api/async/v1/interfaces"
+	interfaces "github.com/dvonthenen/symbl-go-sdk/pkg/client/interfaces"
 )
 
-func (c *Client) GetConversations(ctx context.Context) (*interfaces.ConversationsResult, error) {
+func (c *Client) GetConversations(ctx context.Context) (*asyncinterfaces.ConversationsResult, error) {
 	klog.V(6).Infof("async.GetConversations ENTER\n")
 
 	// checks
@@ -35,11 +34,11 @@ func (c *Client) GetConversations(ctx context.Context) (*interfaces.Conversation
 	}
 
 	// check the status
-	var result interfaces.ConversationsResult
+	var result asyncinterfaces.ConversationsResult
 
 	err = c.Client.Do(ctx, req, &result)
 
-	if e, ok := err.(*symbl.StatusError); ok {
+	if e, ok := err.(*interfaces.StatusError); ok {
 		if e.Resp.StatusCode != http.StatusOK {
 			klog.V(1).Infof("HTTP Code: %v\n", e.Resp.StatusCode)
 			klog.V(6).Infof("async.GetConversations LEAVE\n")
@@ -52,7 +51,7 @@ func (c *Client) GetConversations(ctx context.Context) (*interfaces.Conversation
 	return &result, nil
 }
 
-func (c *Client) GetConversation(ctx context.Context, conversationId string) (*interfaces.Conversation, error) {
+func (c *Client) GetConversation(ctx context.Context, conversationId string) (*asyncinterfaces.Conversation, error) {
 	klog.V(6).Infof("async.GetConversation ENTER\n")
 
 	// checks
@@ -77,11 +76,11 @@ func (c *Client) GetConversation(ctx context.Context, conversationId string) (*i
 	}
 
 	// check the status
-	var result interfaces.Conversation
+	var result asyncinterfaces.Conversation
 
 	err = c.Client.Do(ctx, req, &result)
 
-	if e, ok := err.(*symbl.StatusError); ok {
+	if e, ok := err.(*interfaces.StatusError); ok {
 		if e.Resp.StatusCode != http.StatusOK {
 			klog.V(1).Infof("HTTP Code: %v\n", e.Resp.StatusCode)
 			klog.V(6).Infof("async.GetConversations LEAVE\n")

--- a/pkg/api/async/v1/intelligence.go
+++ b/pkg/api/async/v1/intelligence.go
@@ -9,13 +9,12 @@ import (
 
 	klog "k8s.io/klog/v2"
 
+	asyncinterfaces "github.com/dvonthenen/symbl-go-sdk/pkg/api/async/v1/interfaces"
 	version "github.com/dvonthenen/symbl-go-sdk/pkg/api/version"
-	symbl "github.com/dvonthenen/symbl-go-sdk/pkg/client"
-
-	interfaces "github.com/dvonthenen/symbl-go-sdk/pkg/api/async/v1/interfaces"
+	interfaces "github.com/dvonthenen/symbl-go-sdk/pkg/client/interfaces"
 )
 
-func (c *Client) GetTopics(ctx context.Context, conversationId string) (*interfaces.TopicResult, error) {
+func (c *Client) GetTopics(ctx context.Context, conversationId string) (*asyncinterfaces.TopicResult, error) {
 	klog.V(6).Infof("async.GetTopics ENTER\n")
 
 	// checks
@@ -40,11 +39,11 @@ func (c *Client) GetTopics(ctx context.Context, conversationId string) (*interfa
 	}
 
 	// check the status
-	var result interfaces.TopicResult
+	var result asyncinterfaces.TopicResult
 
 	err = c.Client.Do(ctx, req, &result)
 
-	if e, ok := err.(*symbl.StatusError); ok {
+	if e, ok := err.(*interfaces.StatusError); ok {
 		if e.Resp.StatusCode != http.StatusOK {
 			klog.V(1).Infof("HTTP Code: %v\n", e.Resp.StatusCode)
 			klog.V(6).Infof("async.GetTopics LEAVE\n")
@@ -57,7 +56,7 @@ func (c *Client) GetTopics(ctx context.Context, conversationId string) (*interfa
 	return &result, nil
 }
 
-func (c *Client) GetQuestions(ctx context.Context, conversationId string) (*interfaces.QuestionResult, error) {
+func (c *Client) GetQuestions(ctx context.Context, conversationId string) (*asyncinterfaces.QuestionResult, error) {
 	klog.V(6).Infof("async.GetQuestions ENTER\n")
 
 	// checks
@@ -82,11 +81,11 @@ func (c *Client) GetQuestions(ctx context.Context, conversationId string) (*inte
 	}
 
 	// check the status
-	var result interfaces.QuestionResult
+	var result asyncinterfaces.QuestionResult
 
 	err = c.Client.Do(ctx, req, &result)
 
-	if e, ok := err.(*symbl.StatusError); ok {
+	if e, ok := err.(*interfaces.StatusError); ok {
 		if e.Resp.StatusCode != http.StatusOK {
 			klog.V(1).Infof("HTTP Code: %v\n", e.Resp.StatusCode)
 			klog.V(6).Infof("async.GetQuestions LEAVE\n")
@@ -99,7 +98,7 @@ func (c *Client) GetQuestions(ctx context.Context, conversationId string) (*inte
 	return &result, nil
 }
 
-func (c *Client) GetFollowUps(ctx context.Context, conversationId string) (*interfaces.FollowUpResult, error) {
+func (c *Client) GetFollowUps(ctx context.Context, conversationId string) (*asyncinterfaces.FollowUpResult, error) {
 	klog.V(6).Infof("async.GetFollowUps ENTER\n")
 
 	// checks
@@ -124,11 +123,11 @@ func (c *Client) GetFollowUps(ctx context.Context, conversationId string) (*inte
 	}
 
 	// check the status
-	var result interfaces.FollowUpResult
+	var result asyncinterfaces.FollowUpResult
 
 	err = c.Client.Do(ctx, req, &result)
 
-	if e, ok := err.(*symbl.StatusError); ok {
+	if e, ok := err.(*interfaces.StatusError); ok {
 		if e.Resp.StatusCode != http.StatusOK {
 			klog.V(1).Infof("HTTP Code: %v\n", e.Resp.StatusCode)
 			klog.V(6).Infof("async.GetFollowUps LEAVE\n")
@@ -141,7 +140,7 @@ func (c *Client) GetFollowUps(ctx context.Context, conversationId string) (*inte
 	return &result, nil
 }
 
-func (c *Client) GetEntities(ctx context.Context, conversationId string) (*interfaces.EntityResult, error) {
+func (c *Client) GetEntities(ctx context.Context, conversationId string) (*asyncinterfaces.EntityResult, error) {
 	klog.V(6).Infof("async.GetEntities ENTER\n")
 
 	// checks
@@ -166,11 +165,11 @@ func (c *Client) GetEntities(ctx context.Context, conversationId string) (*inter
 	}
 
 	// check the status
-	var result interfaces.EntityResult
+	var result asyncinterfaces.EntityResult
 
 	err = c.Client.Do(ctx, req, &result)
 
-	if e, ok := err.(*symbl.StatusError); ok {
+	if e, ok := err.(*interfaces.StatusError); ok {
 		if e.Resp.StatusCode != http.StatusOK {
 			klog.V(1).Infof("HTTP Code: %v\n", e.Resp.StatusCode)
 			klog.V(6).Infof("async.GetEntities LEAVE\n")
@@ -183,7 +182,7 @@ func (c *Client) GetEntities(ctx context.Context, conversationId string) (*inter
 	return &result, nil
 }
 
-func (c *Client) GetActionItems(ctx context.Context, conversationId string) (*interfaces.ActionItemResult, error) {
+func (c *Client) GetActionItems(ctx context.Context, conversationId string) (*asyncinterfaces.ActionItemResult, error) {
 	klog.V(6).Infof("async.GetActionItems ENTER\n")
 
 	// checks
@@ -208,11 +207,11 @@ func (c *Client) GetActionItems(ctx context.Context, conversationId string) (*in
 	}
 
 	// check the status
-	var result interfaces.ActionItemResult
+	var result asyncinterfaces.ActionItemResult
 
 	err = c.Client.Do(ctx, req, &result)
 
-	if e, ok := err.(*symbl.StatusError); ok {
+	if e, ok := err.(*interfaces.StatusError); ok {
 		if e.Resp.StatusCode != http.StatusOK {
 			klog.V(1).Infof("HTTP Code: %v\n", e.Resp.StatusCode)
 			klog.V(6).Infof("async.GetActionItems LEAVE\n")
@@ -225,7 +224,7 @@ func (c *Client) GetActionItems(ctx context.Context, conversationId string) (*in
 	return &result, nil
 }
 
-func (c *Client) GetMessages(ctx context.Context, conversationId string) (*interfaces.MessageResult, error) {
+func (c *Client) GetMessages(ctx context.Context, conversationId string) (*asyncinterfaces.MessageResult, error) {
 	klog.V(6).Infof("async.GetMessages ENTER\n")
 
 	// checks
@@ -250,11 +249,11 @@ func (c *Client) GetMessages(ctx context.Context, conversationId string) (*inter
 	}
 
 	// check the status
-	var result interfaces.MessageResult
+	var result asyncinterfaces.MessageResult
 
 	err = c.Client.Do(ctx, req, &result)
 
-	if e, ok := err.(*symbl.StatusError); ok {
+	if e, ok := err.(*interfaces.StatusError); ok {
 		if e.Resp.StatusCode != http.StatusOK {
 			klog.V(1).Infof("HTTP Code: %v\n", e.Resp.StatusCode)
 			klog.V(6).Infof("async.GetMessages LEAVE\n")
@@ -267,7 +266,7 @@ func (c *Client) GetMessages(ctx context.Context, conversationId string) (*inter
 	return &result, nil
 }
 
-func (c *Client) GetSummary(ctx context.Context, conversationId string) (*interfaces.SummaryResult, error) {
+func (c *Client) GetSummary(ctx context.Context, conversationId string) (*asyncinterfaces.SummaryResult, error) {
 	klog.V(6).Infof("async.GetSummary ENTER\n")
 
 	// checks
@@ -292,11 +291,11 @@ func (c *Client) GetSummary(ctx context.Context, conversationId string) (*interf
 	}
 
 	// check the status
-	var result interfaces.SummaryResult
+	var result asyncinterfaces.SummaryResult
 
 	err = c.Client.Do(ctx, req, &result)
 
-	if e, ok := err.(*symbl.StatusError); ok {
+	if e, ok := err.(*interfaces.StatusError); ok {
 		if e.Resp.StatusCode != http.StatusOK {
 			klog.V(1).Infof("HTTP Code: %v\n", e.Resp.StatusCode)
 			klog.V(6).Infof("async.GetSummary LEAVE\n")
@@ -309,7 +308,7 @@ func (c *Client) GetSummary(ctx context.Context, conversationId string) (*interf
 	return &result, nil
 }
 
-func (c *Client) GetAnalytics(ctx context.Context, conversationId string) (*interfaces.AnalyticsResult, error) {
+func (c *Client) GetAnalytics(ctx context.Context, conversationId string) (*asyncinterfaces.AnalyticsResult, error) {
 	klog.V(6).Infof("async.GetAnalytics ENTER\n")
 
 	// checks
@@ -334,11 +333,11 @@ func (c *Client) GetAnalytics(ctx context.Context, conversationId string) (*inte
 	}
 
 	// check the status
-	var result interfaces.AnalyticsResult
+	var result asyncinterfaces.AnalyticsResult
 
 	err = c.Client.Do(ctx, req, &result)
 
-	if e, ok := err.(*symbl.StatusError); ok {
+	if e, ok := err.(*interfaces.StatusError); ok {
 		if e.Resp.StatusCode != http.StatusOK {
 			klog.V(1).Infof("HTTP Code: %v\n", e.Resp.StatusCode)
 			klog.V(6).Infof("async.GetAnalytics LEAVE\n")
@@ -351,7 +350,7 @@ func (c *Client) GetAnalytics(ctx context.Context, conversationId string) (*inte
 	return &result, nil
 }
 
-func (c *Client) GetTracker(ctx context.Context, conversationId string) (*interfaces.TrackerResult, error) {
+func (c *Client) GetTracker(ctx context.Context, conversationId string) (*asyncinterfaces.TrackerResult, error) {
 	klog.V(6).Infof("async.GetTracker ENTER\n")
 
 	// checks
@@ -376,11 +375,11 @@ func (c *Client) GetTracker(ctx context.Context, conversationId string) (*interf
 	}
 
 	// check the status
-	var result interfaces.TrackerResult
+	var result asyncinterfaces.TrackerResult
 
 	err = c.Client.Do(ctx, req, &result)
 
-	if e, ok := err.(*symbl.StatusError); ok {
+	if e, ok := err.(*interfaces.StatusError); ok {
 		if e.Resp.StatusCode != http.StatusOK {
 			klog.V(1).Infof("HTTP Code: %v\n", e.Resp.StatusCode)
 			klog.V(6).Infof("async.GetTracker LEAVE\n")

--- a/pkg/api/async/v1/members.go
+++ b/pkg/api/async/v1/members.go
@@ -11,13 +11,12 @@ import (
 
 	klog "k8s.io/klog/v2"
 
+	asyncinterfaces "github.com/dvonthenen/symbl-go-sdk/pkg/api/async/v1/interfaces"
 	version "github.com/dvonthenen/symbl-go-sdk/pkg/api/version"
-	symbl "github.com/dvonthenen/symbl-go-sdk/pkg/client"
-
-	interfaces "github.com/dvonthenen/symbl-go-sdk/pkg/api/async/v1/interfaces"
+	interfaces "github.com/dvonthenen/symbl-go-sdk/pkg/client/interfaces"
 )
 
-func (c *Client) GetMembers(ctx context.Context, conversationId string) (*interfaces.MembersResult, error) {
+func (c *Client) GetMembers(ctx context.Context, conversationId string) (*asyncinterfaces.MembersResult, error) {
 	klog.V(6).Infof("async.GetMembers ENTER\n")
 
 	// checks
@@ -42,11 +41,11 @@ func (c *Client) GetMembers(ctx context.Context, conversationId string) (*interf
 	}
 
 	// check the status
-	var result interfaces.MembersResult
+	var result asyncinterfaces.MembersResult
 
 	err = c.Client.Do(ctx, req, &result)
 
-	if e, ok := err.(*symbl.StatusError); ok {
+	if e, ok := err.(*interfaces.StatusError); ok {
 		if e.Resp.StatusCode != http.StatusOK {
 			klog.V(1).Infof("HTTP Code: %v\n", e.Resp.StatusCode)
 			klog.V(6).Infof("async.GetMembers LEAVE\n")
@@ -59,7 +58,7 @@ func (c *Client) GetMembers(ctx context.Context, conversationId string) (*interf
 	return &result, nil
 }
 
-func (c *Client) UpdateMember(ctx context.Context, conversationId string, member interfaces.Member) error {
+func (c *Client) UpdateMember(ctx context.Context, conversationId string, member asyncinterfaces.Member) error {
 	klog.V(6).Infof("async.UpdateMember ENTER\n")
 
 	// checks
@@ -93,7 +92,7 @@ func (c *Client) UpdateMember(ctx context.Context, conversationId string, member
 	// check the status
 	err = c.Client.Do(ctx, req, nil)
 
-	if e, ok := err.(*symbl.StatusError); ok {
+	if e, ok := err.(*interfaces.StatusError); ok {
 		if e.Resp.StatusCode != http.StatusOK {
 			klog.V(1).Infof("HTTP Code: %v\n", e.Resp.StatusCode)
 			klog.V(6).Infof("async.UpdateMember LEAVE\n")
@@ -106,7 +105,7 @@ func (c *Client) UpdateMember(ctx context.Context, conversationId string, member
 	return nil
 }
 
-func (c *Client) UpdateSpeakers(ctx context.Context, conversationId string, speakers interfaces.UpdateSpeakerRequest) error {
+func (c *Client) UpdateSpeakers(ctx context.Context, conversationId string, speakers asyncinterfaces.UpdateSpeakerRequest) error {
 	klog.V(6).Infof("async.UpdateSpeakers ENTER\n")
 
 	// checks
@@ -140,7 +139,7 @@ func (c *Client) UpdateSpeakers(ctx context.Context, conversationId string, spea
 	// check the status
 	err = c.Client.Do(ctx, req, nil)
 
-	if e, ok := err.(*symbl.StatusError); ok {
+	if e, ok := err.(*interfaces.StatusError); ok {
 		if e.Resp.StatusCode != http.StatusOK {
 			klog.V(1).Infof("HTTP Code: %v\n", e.Resp.StatusCode)
 			klog.V(6).Infof("async.UpdateSpeakers LEAVE\n")

--- a/pkg/api/async/v1/summaryui.go
+++ b/pkg/api/async/v1/summaryui.go
@@ -13,14 +13,13 @@ import (
 
 	klog "k8s.io/klog/v2"
 
+	asyncinterfaces "github.com/dvonthenen/symbl-go-sdk/pkg/api/async/v1/interfaces"
 	common "github.com/dvonthenen/symbl-go-sdk/pkg/api/common"
 	version "github.com/dvonthenen/symbl-go-sdk/pkg/api/version"
-	symbl "github.com/dvonthenen/symbl-go-sdk/pkg/client"
-
-	interfaces "github.com/dvonthenen/symbl-go-sdk/pkg/api/async/v1/interfaces"
+	interfaces "github.com/dvonthenen/symbl-go-sdk/pkg/client/interfaces"
 )
 
-func (c *Client) GetSummaryUI(ctx context.Context, conversationId string, uri string) (*interfaces.SummaryUIResult, error) {
+func (c *Client) GetSummaryUI(ctx context.Context, conversationId string, uri string) (*asyncinterfaces.SummaryUIResult, error) {
 	// checks
 	if ctx == nil {
 		ctx = context.Background()
@@ -32,7 +31,7 @@ func (c *Client) GetSummaryUI(ctx context.Context, conversationId string, uri st
 
 	// text
 	if len(uri) == 0 {
-		request := interfaces.TextSummaryRequest{
+		request := asyncinterfaces.TextSummaryRequest{
 			Name: "verbose-text-summary",
 		}
 		return c.GetTextSummaryUI(ctx, conversationId, request)
@@ -60,7 +59,7 @@ func (c *Client) GetSummaryUI(ctx context.Context, conversationId string, uri st
 	case common.AudioTypeMP3:
 	case common.AudioTypeMpeg:
 	case common.AudioTypeWav:
-		request := interfaces.AudioSummaryRequest{
+		request := asyncinterfaces.AudioSummaryRequest{
 			Name:     "audio-summary",
 			AudioURL: uri,
 		}
@@ -68,14 +67,14 @@ func (c *Client) GetSummaryUI(ctx context.Context, conversationId string, uri st
 	}
 
 	// assume video
-	request := interfaces.VideoSummaryRequest{
+	request := asyncinterfaces.VideoSummaryRequest{
 		Name:     "video-summary",
 		VideoURL: uri,
 	}
 	return c.GetVideoSummaryUI(ctx, conversationId, request)
 }
 
-func (c *Client) GetTextSummaryUI(ctx context.Context, conversationId string, request interfaces.TextSummaryRequest) (*interfaces.SummaryUIResult, error) {
+func (c *Client) GetTextSummaryUI(ctx context.Context, conversationId string, request asyncinterfaces.TextSummaryRequest) (*asyncinterfaces.SummaryUIResult, error) {
 	klog.V(6).Infof("async.GetTextSummaryUI ENTER\n")
 
 	// checks
@@ -107,11 +106,11 @@ func (c *Client) GetTextSummaryUI(ctx context.Context, conversationId string, re
 	}
 
 	// check the status
-	var result interfaces.SummaryUIResult
+	var result asyncinterfaces.SummaryUIResult
 
 	err = c.Client.Do(ctx, req, &result)
 
-	if e, ok := err.(*symbl.StatusError); ok {
+	if e, ok := err.(*interfaces.StatusError); ok {
 		if e.Resp.StatusCode != http.StatusOK {
 			klog.V(1).Infof("HTTP Code: %v\n", e.Resp.StatusCode)
 			klog.V(6).Infof("async.GetTextSummaryUI LEAVE\n")
@@ -124,7 +123,7 @@ func (c *Client) GetTextSummaryUI(ctx context.Context, conversationId string, re
 	return &result, nil
 }
 
-func (c *Client) GetAudioSummaryUI(ctx context.Context, conversationId string, request interfaces.AudioSummaryRequest) (*interfaces.SummaryUIResult, error) {
+func (c *Client) GetAudioSummaryUI(ctx context.Context, conversationId string, request asyncinterfaces.AudioSummaryRequest) (*asyncinterfaces.SummaryUIResult, error) {
 	klog.V(6).Infof("async.GetAudioSummaryUI ENTER\n")
 
 	// checks
@@ -156,11 +155,11 @@ func (c *Client) GetAudioSummaryUI(ctx context.Context, conversationId string, r
 	}
 
 	// check the status
-	var result interfaces.SummaryUIResult
+	var result asyncinterfaces.SummaryUIResult
 
 	err = c.Client.Do(ctx, req, &result)
 
-	if e, ok := err.(*symbl.StatusError); ok {
+	if e, ok := err.(*interfaces.StatusError); ok {
 		if e.Resp.StatusCode != http.StatusOK {
 			klog.V(1).Infof("HTTP Code: %v\n", e.Resp.StatusCode)
 			klog.V(6).Infof("async.GetAudioSummaryUI LEAVE\n")
@@ -173,7 +172,7 @@ func (c *Client) GetAudioSummaryUI(ctx context.Context, conversationId string, r
 	return &result, nil
 }
 
-func (c *Client) GetVideoSummaryUI(ctx context.Context, conversationId string, request interfaces.VideoSummaryRequest) (*interfaces.SummaryUIResult, error) {
+func (c *Client) GetVideoSummaryUI(ctx context.Context, conversationId string, request asyncinterfaces.VideoSummaryRequest) (*asyncinterfaces.SummaryUIResult, error) {
 	klog.V(6).Infof("async.GetVideoSummaryUI ENTER\n")
 
 	// checks
@@ -205,11 +204,11 @@ func (c *Client) GetVideoSummaryUI(ctx context.Context, conversationId string, r
 	}
 
 	// check the status
-	var result interfaces.SummaryUIResult
+	var result asyncinterfaces.SummaryUIResult
 
 	err = c.Client.Do(ctx, req, &result)
 
-	if e, ok := err.(*symbl.StatusError); ok {
+	if e, ok := err.(*interfaces.StatusError); ok {
 		if e.Resp.StatusCode != http.StatusOK {
 			klog.V(1).Infof("HTTP Code: %v\n", e.Resp.StatusCode)
 			klog.V(6).Infof("async.GetVideoSummaryUI LEAVE\n")

--- a/pkg/api/management/v1/conversationgroup.go
+++ b/pkg/api/management/v1/conversationgroup.go
@@ -12,12 +12,12 @@ import (
 	validator "gopkg.in/go-playground/validator.v9"
 	klog "k8s.io/klog/v2"
 
-	interfaces "github.com/dvonthenen/symbl-go-sdk/pkg/api/management/v1/interfaces"
+	mgmtinterfaces "github.com/dvonthenen/symbl-go-sdk/pkg/api/management/v1/interfaces"
 	version "github.com/dvonthenen/symbl-go-sdk/pkg/api/version"
-	symbl "github.com/dvonthenen/symbl-go-sdk/pkg/client"
+	interfaces "github.com/dvonthenen/symbl-go-sdk/pkg/client/interfaces"
 )
 
-func (m *Management) GetConversationGroups(ctx context.Context) (*interfaces.ConversationGroupsResponse, error) {
+func (m *Management) GetConversationGroups(ctx context.Context) (*mgmtinterfaces.ConversationGroupsResponse, error) {
 	klog.V(6).Infof("mgmt.GetConversationGroups ENTER\n")
 
 	// checks
@@ -37,11 +37,11 @@ func (m *Management) GetConversationGroups(ctx context.Context) (*interfaces.Con
 	}
 
 	// check the status
-	var result interfaces.ConversationGroupsResponse
+	var result mgmtinterfaces.ConversationGroupsResponse
 
 	err = m.Client.Do(ctx, req, &result)
 
-	if e, ok := err.(*symbl.StatusError); ok {
+	if e, ok := err.(*interfaces.StatusError); ok {
 		if e.Resp.StatusCode != http.StatusOK {
 			klog.V(1).Infof("HTTP Code: %v\n", e.Resp.StatusCode)
 			klog.V(6).Infof("mgmt.GetConversationGroups LEAVE\n")
@@ -54,7 +54,7 @@ func (m *Management) GetConversationGroups(ctx context.Context) (*interfaces.Con
 	return &result, nil
 }
 
-func (m *Management) GetConversationGroupById(ctx context.Context, conversationGroupId string) (*interfaces.ConversationGroupResponse, error) {
+func (m *Management) GetConversationGroupById(ctx context.Context, conversationGroupId string) (*mgmtinterfaces.ConversationGroupResponse, error) {
 	klog.V(6).Infof("mgmt.GetConversationGroupById ENTER\n")
 
 	// checks
@@ -74,11 +74,11 @@ func (m *Management) GetConversationGroupById(ctx context.Context, conversationG
 	}
 
 	// check the status
-	var result interfaces.ConversationGroupResponse
+	var result mgmtinterfaces.ConversationGroupResponse
 
 	err = m.Client.Do(ctx, req, &result)
 
-	if e, ok := err.(*symbl.StatusError); ok {
+	if e, ok := err.(*interfaces.StatusError); ok {
 		if e.Resp.StatusCode != http.StatusOK {
 			klog.V(1).Infof("HTTP Code: %v\n", e.Resp.StatusCode)
 			klog.V(6).Infof("mgmt.GetConversationGroupById LEAVE\n")
@@ -91,7 +91,7 @@ func (m *Management) GetConversationGroupById(ctx context.Context, conversationG
 	return &result, nil
 }
 
-func (m *Management) CreateConversationGroup(ctx context.Context, request interfaces.Group) (*interfaces.ConversationGroupResponse, error) {
+func (m *Management) CreateConversationGroup(ctx context.Context, request mgmtinterfaces.Group) (*mgmtinterfaces.ConversationGroupResponse, error) {
 	klog.V(6).Infof("mgmt.CreateConversationGroup ENTER\n")
 
 	// checks
@@ -129,11 +129,11 @@ func (m *Management) CreateConversationGroup(ctx context.Context, request interf
 	}
 
 	// check the status
-	var result interfaces.ConversationGroupResponse
+	var result mgmtinterfaces.ConversationGroupResponse
 
 	err = m.Client.Do(ctx, req, &result)
 
-	if e, ok := err.(*symbl.StatusError); ok {
+	if e, ok := err.(*interfaces.StatusError); ok {
 		if e.Resp.StatusCode != http.StatusOK {
 			klog.V(1).Infof("HTTP Code: %v\n", e.Resp.StatusCode)
 			klog.V(6).Infof("mgmt.CreateConversationGroup LEAVE\n")
@@ -146,7 +146,7 @@ func (m *Management) CreateConversationGroup(ctx context.Context, request interf
 	return &result, nil
 }
 
-func (m *Management) UpdateConversationGroup(ctx context.Context, request interfaces.Group) (*interfaces.ConversationGroupResponse, error) {
+func (m *Management) UpdateConversationGroup(ctx context.Context, request mgmtinterfaces.Group) (*mgmtinterfaces.ConversationGroupResponse, error) {
 	klog.V(6).Infof("mgmt.UpdateConversationGroup ENTER\n")
 
 	// checks
@@ -190,11 +190,11 @@ func (m *Management) UpdateConversationGroup(ctx context.Context, request interf
 	}
 
 	// check the status
-	var result interfaces.ConversationGroupResponse
+	var result mgmtinterfaces.ConversationGroupResponse
 
 	err = m.Client.Do(ctx, req, &result)
 
-	if e, ok := err.(*symbl.StatusError); ok {
+	if e, ok := err.(*interfaces.StatusError); ok {
 		if e.Resp.StatusCode != http.StatusOK {
 			klog.V(1).Infof("HTTP Code: %v\n", e.Resp.StatusCode)
 			klog.V(6).Infof("mgmt.UpdateConversationGroup LEAVE\n")
@@ -236,7 +236,7 @@ func (m *Management) DeleteConversationGroup(ctx context.Context, conversationGr
 	// check the status
 	err = m.Client.Do(ctx, req, nil)
 
-	if e, ok := err.(*symbl.StatusError); ok {
+	if e, ok := err.(*interfaces.StatusError); ok {
 		if e.Resp.StatusCode != http.StatusOK {
 			klog.V(1).Infof("HTTP Code: %v\n", e.Resp.StatusCode)
 			klog.V(6).Infof("mgmt.DeleteConversationGroup LEAVE\n")

--- a/pkg/api/management/v1/entities.go
+++ b/pkg/api/management/v1/entities.go
@@ -12,12 +12,12 @@ import (
 	validator "gopkg.in/go-playground/validator.v9"
 	klog "k8s.io/klog/v2"
 
-	interfaces "github.com/dvonthenen/symbl-go-sdk/pkg/api/management/v1/interfaces"
+	mgmtinterfaces "github.com/dvonthenen/symbl-go-sdk/pkg/api/management/v1/interfaces"
 	version "github.com/dvonthenen/symbl-go-sdk/pkg/api/version"
-	symbl "github.com/dvonthenen/symbl-go-sdk/pkg/client"
+	interfaces "github.com/dvonthenen/symbl-go-sdk/pkg/client/interfaces"
 )
 
-func (m *Management) GetEntites(ctx context.Context) (*interfaces.EntitiesResponse, error) {
+func (m *Management) GetEntites(ctx context.Context) (*mgmtinterfaces.EntitiesResponse, error) {
 	klog.V(6).Infof("mgmt.GetEntites ENTER\n")
 
 	// checks
@@ -37,11 +37,11 @@ func (m *Management) GetEntites(ctx context.Context) (*interfaces.EntitiesRespon
 	}
 
 	// check the status
-	var result interfaces.EntitiesResponse
+	var result mgmtinterfaces.EntitiesResponse
 
 	err = m.Client.Do(ctx, req, &result)
 
-	if e, ok := err.(*symbl.StatusError); ok {
+	if e, ok := err.(*interfaces.StatusError); ok {
 		if e.Resp.StatusCode != http.StatusOK {
 			klog.V(1).Infof("HTTP Code: %v\n", e.Resp.StatusCode)
 			klog.V(6).Infof("mgmt.GetEntites LEAVE\n")
@@ -54,7 +54,7 @@ func (m *Management) GetEntites(ctx context.Context) (*interfaces.EntitiesRespon
 	return &result, nil
 }
 
-func (m *Management) GetEntitById(ctx context.Context, entityId string) (*interfaces.Entity, error) {
+func (m *Management) GetEntitById(ctx context.Context, entityId string) (*mgmtinterfaces.Entity, error) {
 	klog.V(6).Infof("mgmt.GetEntitById ENTER\n")
 
 	// checks
@@ -74,11 +74,11 @@ func (m *Management) GetEntitById(ctx context.Context, entityId string) (*interf
 	}
 
 	// check the status
-	var result interfaces.Entity
+	var result mgmtinterfaces.Entity
 
 	err = m.Client.Do(ctx, req, &result)
 
-	if e, ok := err.(*symbl.StatusError); ok {
+	if e, ok := err.(*interfaces.StatusError); ok {
 		if e.Resp.StatusCode != http.StatusOK {
 			klog.V(1).Infof("HTTP Code: %v\n", e.Resp.StatusCode)
 			klog.V(6).Infof("mgmt.GetEntitById LEAVE\n")
@@ -94,7 +94,7 @@ func (m *Management) GetEntitById(ctx context.Context, entityId string) (*interf
 /*
 	TODO: create doesn't return Entity object that's populated
 */
-func (m *Management) CreateEntity(ctx context.Context, request interfaces.CreateEntityRequest) (*interfaces.EntitiesResponse, error) {
+func (m *Management) CreateEntity(ctx context.Context, request mgmtinterfaces.CreateEntityRequest) (*mgmtinterfaces.EntitiesResponse, error) {
 	klog.V(6).Infof("mgmt.CreateEntity ENTER\n")
 
 	// checks
@@ -132,11 +132,11 @@ func (m *Management) CreateEntity(ctx context.Context, request interfaces.Create
 	}
 
 	// check the status
-	var result interfaces.EntitiesResponse
+	var result mgmtinterfaces.EntitiesResponse
 
 	err = m.Client.Do(ctx, req, &result)
 
-	if e, ok := err.(*symbl.StatusError); ok {
+	if e, ok := err.(*interfaces.StatusError); ok {
 		if e.Resp.StatusCode != http.StatusOK {
 			klog.V(1).Infof("HTTP Code: %v\n", e.Resp.StatusCode)
 			klog.V(6).Infof("mgmt.CreateEntity LEAVE\n")
@@ -149,7 +149,7 @@ func (m *Management) CreateEntity(ctx context.Context, request interfaces.Create
 	return &result, nil
 }
 
-func (m *Management) UpdateEntity(ctx context.Context, entityId string, request interfaces.Entity) (*interfaces.EntityResponse, error) {
+func (m *Management) UpdateEntity(ctx context.Context, entityId string, request mgmtinterfaces.Entity) (*mgmtinterfaces.EntityResponse, error) {
 	klog.V(6).Infof("mgmt.UpdateEntity ENTER\n")
 
 	// checks
@@ -187,11 +187,11 @@ func (m *Management) UpdateEntity(ctx context.Context, entityId string, request 
 	}
 
 	// check the status
-	var result interfaces.EntityResponse
+	var result mgmtinterfaces.EntityResponse
 
 	err = m.Client.Do(ctx, req, &result)
 
-	if e, ok := err.(*symbl.StatusError); ok {
+	if e, ok := err.(*interfaces.StatusError); ok {
 		if e.Resp.StatusCode != http.StatusOK {
 			klog.V(1).Infof("HTTP Code: %v\n", e.Resp.StatusCode)
 			klog.V(6).Infof("mgmt.UpdateEntity LEAVE\n")
@@ -233,7 +233,7 @@ func (m *Management) DeleteEntity(ctx context.Context, entityId string) error {
 	// check the status
 	err = m.Client.Do(ctx, req, nil)
 
-	if e, ok := err.(*symbl.StatusError); ok {
+	if e, ok := err.(*interfaces.StatusError); ok {
 		if e.Resp.StatusCode != http.StatusOK {
 			klog.V(1).Infof("HTTP Code: %v\n", e.Resp.StatusCode)
 			klog.V(6).Infof("mgmt.DeleteEntity LEAVE\n")
@@ -275,7 +275,7 @@ func (m *Management) DeleteEntityBySubType(ctx context.Context, subType string) 
 	// check the status
 	err = m.Client.Do(ctx, req, nil)
 
-	if e, ok := err.(*symbl.StatusError); ok {
+	if e, ok := err.(*interfaces.StatusError); ok {
 		if e.Resp.StatusCode != http.StatusOK {
 			klog.V(1).Infof("HTTP Code: %v\n", e.Resp.StatusCode)
 			klog.V(6).Infof("mgmt.DeleteEntityBySubType LEAVE\n")

--- a/pkg/api/management/v1/trackers.go
+++ b/pkg/api/management/v1/trackers.go
@@ -12,12 +12,12 @@ import (
 	validator "gopkg.in/go-playground/validator.v9"
 	klog "k8s.io/klog/v2"
 
-	interfaces "github.com/dvonthenen/symbl-go-sdk/pkg/api/management/v1/interfaces"
+	mgmtinterfaces "github.com/dvonthenen/symbl-go-sdk/pkg/api/management/v1/interfaces"
 	version "github.com/dvonthenen/symbl-go-sdk/pkg/api/version"
-	symbl "github.com/dvonthenen/symbl-go-sdk/pkg/client"
+	interfaces "github.com/dvonthenen/symbl-go-sdk/pkg/client/interfaces"
 )
 
-func (m *Management) GetTrackers(ctx context.Context) (*interfaces.TrackersResponse, error) {
+func (m *Management) GetTrackers(ctx context.Context) (*mgmtinterfaces.TrackersResponse, error) {
 	klog.V(6).Infof("mgmt.GetTrackers ENTER\n")
 
 	// checks
@@ -37,11 +37,11 @@ func (m *Management) GetTrackers(ctx context.Context) (*interfaces.TrackersRespo
 	}
 
 	// check the status
-	var result interfaces.TrackersResponse
+	var result mgmtinterfaces.TrackersResponse
 
 	err = m.Client.Do(ctx, req, &result)
 
-	if e, ok := err.(*symbl.StatusError); ok {
+	if e, ok := err.(*interfaces.StatusError); ok {
 		if e.Resp.StatusCode != http.StatusOK {
 			klog.V(1).Infof("HTTP Code: %v\n", e.Resp.StatusCode)
 			klog.V(6).Infof("mgmt.GetTrackers LEAVE\n")
@@ -54,7 +54,7 @@ func (m *Management) GetTrackers(ctx context.Context) (*interfaces.TrackersRespo
 	return &result, nil
 }
 
-func (m *Management) CreateTracker(ctx context.Context, request interfaces.TrackerRequest) (*interfaces.TrackerResponse, error) {
+func (m *Management) CreateTracker(ctx context.Context, request mgmtinterfaces.TrackerRequest) (*mgmtinterfaces.TrackerResponse, error) {
 	klog.V(6).Infof("mgmt.CreateTracker ENTER\n")
 
 	// checks
@@ -92,11 +92,11 @@ func (m *Management) CreateTracker(ctx context.Context, request interfaces.Track
 	}
 
 	// check the status
-	var result interfaces.TrackerResponse
+	var result mgmtinterfaces.TrackerResponse
 
 	err = m.Client.Do(ctx, req, &result)
 
-	if e, ok := err.(*symbl.StatusError); ok {
+	if e, ok := err.(*interfaces.StatusError); ok {
 		if e.Resp.StatusCode != http.StatusOK {
 			klog.V(1).Infof("HTTP Code: %v\n", e.Resp.StatusCode)
 			klog.V(6).Infof("mgmt.CreateTracker LEAVE\n")
@@ -109,7 +109,7 @@ func (m *Management) CreateTracker(ctx context.Context, request interfaces.Track
 	return &result, nil
 }
 
-func (m *Management) UpdateTracker(ctx context.Context, trackerId string, request interfaces.UpdateTrackerRequest) (*interfaces.TrackerResponse, error) {
+func (m *Management) UpdateTracker(ctx context.Context, trackerId string, request mgmtinterfaces.UpdateTrackerRequest) (*mgmtinterfaces.TrackerResponse, error) {
 	klog.V(6).Infof("mgmt.UpdateTracker ENTER\n")
 
 	// checks
@@ -147,11 +147,11 @@ func (m *Management) UpdateTracker(ctx context.Context, trackerId string, reques
 	}
 
 	// check the status
-	var result interfaces.TrackerResponse
+	var result mgmtinterfaces.TrackerResponse
 
 	err = m.Client.Do(ctx, req, &result)
 
-	if e, ok := err.(*symbl.StatusError); ok {
+	if e, ok := err.(*interfaces.StatusError); ok {
 		if e.Resp.StatusCode != http.StatusOK {
 			klog.V(1).Infof("HTTP Code: %v\n", e.Resp.StatusCode)
 			klog.V(6).Infof("mgmt.UpdateTracker LEAVE\n")
@@ -193,7 +193,7 @@ func (m *Management) DeleteTracker(ctx context.Context, trackerId string) error 
 	// check the status
 	err = m.Client.Do(ctx, req, nil)
 
-	if e, ok := err.(*symbl.StatusError); ok {
+	if e, ok := err.(*interfaces.StatusError); ok {
 		if e.Resp.StatusCode != http.StatusOK {
 			klog.V(1).Infof("HTTP Code: %v\n", e.Resp.StatusCode)
 			klog.V(6).Infof("mgmt.DeleteTracker LEAVE\n")

--- a/pkg/api/streaming/v1/interfaces/interface.go
+++ b/pkg/api/streaming/v1/interfaces/interface.go
@@ -10,7 +10,7 @@ type InsightCallback interface {
 	InsightResponseMessage(ir *InsightResponse) error
 	TopicResponseMessage(tr *TopicResponse) error
 	TrackerResponseMessage(tr *TrackerResponse) error
-	EntityResponseMessage(tr *EntityResponse) error
+	EntityResponseMessage(er *EntityResponse) error
 	TeardownConversation(tm *TeardownMessage) error
 	UserDefinedMessage(data []byte) error
 	UnhandledMessage(byMsg []byte) error

--- a/pkg/api/streaming/v1/router.go
+++ b/pkg/api/streaming/v1/router.go
@@ -100,7 +100,7 @@ func (smr *SymblMessageRouter) handlePlatformMessage(byMsg []byte) error {
 		return smr.TeardownConversation(byMsg)
 	case MessageTypeTeardownRecognition:
 		klog.V(3).Infof("Symbl Platform Teardown Recognition\n")
-	// pass insights to the user
+	// transcription
 	case interfaces.MessageTypeRecognitionResult:
 		return smr.RecognitionResultMessage(byMsg)
 	// error

--- a/pkg/client/interfaces/types-rest.go
+++ b/pkg/client/interfaces/types-rest.go
@@ -3,25 +3,9 @@
 
 package interfaces
 
-import (
-	"fmt"
-
-	rest "github.com/dvonthenen/symbl-go-sdk/pkg/client/rest"
-)
-
 /*
 	Symbl REST API
 */
-type HeadersContext struct{}
-
-type StatusError struct {
-	*rest.StatusError
-}
-
-func (e *StatusError) Error() string {
-	return fmt.Sprintf("%s %s: %s", e.Resp.Request.Method, e.Resp.Request.URL, e.Resp.Status)
-}
-
 // Credentials is the input needed to login to the Symbl.ai platform
 type Credentials struct {
 	Type      string `json:"type"`

--- a/pkg/client/interfaces/utils.go
+++ b/pkg/client/interfaces/utils.go
@@ -1,0 +1,51 @@
+// Copyright 2022 Symbl.ai SDK contributors. All Rights Reserved.
+// SPDX-License-Identifier: MIT
+
+package interfaces
+
+import (
+	"bytes"
+	"context"
+	"fmt"
+	"net/http"
+)
+
+/*
+	custom headers and configuration options
+*/
+// signer
+type Signer interface {
+	SignRequest(*http.Request) error
+}
+
+type SignerContext struct{}
+
+func WithSigner(ctx context.Context, s Signer) context.Context {
+	return context.WithValue(ctx, SignerContext{}, s)
+}
+
+// header
+type HeadersContext struct{}
+
+func WithCustomHeaders(ctx context.Context, headers http.Header) context.Context {
+	return context.WithValue(ctx, HeadersContext{}, headers)
+}
+
+/*
+	RawResponse may be used with the Do method as the resBody argument in order
+	to capture the raw response data.
+*/
+type RawResponse struct {
+	bytes.Buffer
+}
+
+/*
+	Error handling
+*/
+type StatusError struct {
+	Resp *http.Response
+}
+
+func (e *StatusError) Error() string {
+	return fmt.Sprintf("%s %s: %s", e.Resp.Request.Method, e.Resp.Request.URL, e.Resp.Status)
+}

--- a/pkg/client/rest/types.go
+++ b/pkg/client/rest/types.go
@@ -4,9 +4,6 @@
 package rest
 
 import (
-	"bytes"
-	"fmt"
-	"net/http"
 	"time"
 )
 
@@ -14,20 +11,4 @@ import (
 type AccessToken struct {
 	AccessToken string
 	ExpiresOn   time.Time
-}
-
-// RawResponse may be used with the Do method as the resBody argument in order
-// to capture the raw response data.
-type RawResponse struct {
-	bytes.Buffer
-}
-
-type HeadersContext struct{}
-
-type StatusError struct {
-	Resp *http.Response
-}
-
-func (e *StatusError) Error() string {
-	return fmt.Sprintf("%s %s: %s", e.Resp.Request.Method, e.Resp.Request.URL, e.Resp.Status)
 }

--- a/pkg/client/symbl-stream.go
+++ b/pkg/client/symbl-stream.go
@@ -11,7 +11,7 @@ import (
 
 	streaming "github.com/dvonthenen/symbl-go-sdk/pkg/api/streaming/v1"
 	version "github.com/dvonthenen/symbl-go-sdk/pkg/api/version"
-	cfginterfaces "github.com/dvonthenen/symbl-go-sdk/pkg/client/interfaces"
+	interfaces "github.com/dvonthenen/symbl-go-sdk/pkg/client/interfaces"
 	stream "github.com/dvonthenen/symbl-go-sdk/pkg/client/stream"
 )
 
@@ -22,8 +22,8 @@ const (
 	defaultUserName            string  = "Jane Doe"
 )
 
-func GetDefaultConfig() *cfginterfaces.StreamingConfig {
-	config := &cfginterfaces.StreamingConfig{}
+func GetDefaultConfig() *interfaces.StreamingConfig {
+	config := &interfaces.StreamingConfig{}
 
 	config.Type = streaming.TypeRequestStart
 	config.InsightTypes = []string{"topic", "question", "action_item", "follow_up"}
@@ -93,7 +93,7 @@ func NewStreamClient(ctx context.Context, options StreamingOptions) (*StreamClie
 		Redirect:       len(options.ProxyAddress) > 0,
 		SkipServerAuth: options.SkipServerAuth,
 	}
-	wsClient, err := stream.NewWebSocketClient(creds, symblStreaming)
+	wsClient, err := stream.NewWebSocketClient(ctx, creds, symblStreaming)
 	if err != nil {
 		klog.V(1).Infof("stream.NewWebSocketClient failed. Err: %v\n", err)
 		klog.V(6).Infof("NewStreamClient LEAVE\n")

--- a/pkg/client/types.go
+++ b/pkg/client/types.go
@@ -4,8 +4,6 @@
 package symbl
 
 import (
-	"fmt"
-
 	rtinterfaces "github.com/dvonthenen/symbl-go-sdk/pkg/api/streaming/v1/interfaces"
 	cfginterfaces "github.com/dvonthenen/symbl-go-sdk/pkg/client/interfaces"
 	interfaces "github.com/dvonthenen/symbl-go-sdk/pkg/client/interfaces"
@@ -42,17 +40,4 @@ type StreamClient struct {
 	symblStreaming stream.WebSocketMessageCallback
 
 	options *StreamingOptions
-}
-
-/*
-	Symbl REST API Internals
-*/
-type HeadersContext struct{}
-
-type StatusError struct {
-	*rest.StatusError
-}
-
-func (e *StatusError) Error() string {
-	return fmt.Sprintf("%s %s: %s", e.Resp.Request.Method, e.Resp.Request.URL, e.Resp.Status)
 }


### PR DESCRIPTION
## What this PR does / why we need it
<!--
Add a detailed explanation of what this PR does and why it is needed.
-->
This restructures some folders and structures to enable Custom Headers for the REST interface. Technically this is a breaking change if you were using Custom Headers, but since it probably wasn't really usable, it's unlikely that this change would actually be breaking anyone.

Aside from the the import renames for consistency and consolidating duplicate structs, the real (and only) change in this PR is enabling/exposing the `HeadersContext` struct here to be added to `Context`:
https://github.com/dvonthenen/symbl-go-sdk/compare/refactor-custom-header-options?expand=1#diff-58330d78127c122d5788607b84c8f3888484cb4662ed403f53e130c3a8daeca0R27-R32

This is how you would pass in custom options in a client application:
```
// custom headers to enable options
headers := http.Header{}
headers.Add("X-ERI-TRANSCRIPTION", "true")
headers.Add("X-ERI-MESSAGING", "true")
ctx = interfaces.WithCustomHeaders(ctx, headers)

// then use CTX like normal    
```


## Which issue(s) this PR fixes
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
NA

## Describe testing done for PR
<!--
Example: I ran the application and it produced the desired output.
-->
Made sure streaming, trackers, and a few other functions still compiled. This should effect run time of the library.

## Special notes for your reviewer
<!--
Add any things that reviewers should be aware of as they review
your PR.

Example: Please verify how I handled foo aligns with overall plan.
-->
NA